### PR TITLE
Normalize weather forecast flag handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,7 @@ trim_trailing_whitespace = true
 # Markdown files (allow trailing spaces for line breaks)
 [*.md]
 trim_trailing_whitespace = false
+spelling_language = en-GB
 
 # Python files
 [*.py]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# places2go Agent Guide
+
+Welcome! This repository powers the **Places2Go** data exploration dashboards. Use this guide to align with the existing tooling,
+documentation, and quality bar before you start coding.
+
+## Tech Stack & Project Layout
+- **Language**: Python 3.9+ with type hints.
+- **Core libraries**: `pandas` for data wrangling, `plotly` for interactive dashboards, and `pytest` for automated tests.
+- **Key modules**:
+  - `scripts/core/` holds data access utilities such as the modular `DataLoader`.
+  - `scripts/visualizations/` contains Plotly dashboard builders (weather, costs, flights, etc.).
+  - `tests/` mirrors the runtime packages; prefer colocating tests with the feature you touch.
+- Review `README.md` for quick-start commands and `docs/` for deeper architecture, process, and workflow references.
+
+## Coding Practices
+- Keep business logic in focused, testable functions. Favour pure, deterministic helpers over implicit globals.
+- Use descriptive names, docstrings, and type annotations for public functions and classes.
+- Follow PEP 8 conventions; the project standardises on Black (line length 88) and mypy type checking as listed in `CONTRIBUTING.md`.
+- Format code with Black before committing (use `black scripts tests` for staged work, or `black .` when in doubt) so `black --check` stays clean in CI.
+- Data wrangling belongs in `scripts/core`; visual formatting and layout tweaks stay under `scripts/visualizations`.
+- When integrating new data sources, extend the existing `DataLoader` patterns (explicit schema validation, null handling, and
+dedicated parsing helpers). Do **not** catch-and-silence import errors—fail fast when dependencies are missing.
+
+## Testing Expectations
+- Back every new logic branch with unit tests in `tests/`. Mirror edge cases already covered (e.g., forecast filtering, empty
+Dashboards) and add regression scenarios when fixing bugs.
+- Use pytest fixtures or inline DataFrames for deterministic coverage. Seed randomness whenever pseudo-random data is required.
+- Run at minimum:
+  - `pytest`
+  - `black --check scripts tests`
+  - `flake8 scripts tests`
+  - `mypy scripts`
+  These commands appear in `CONTRIBUTING.md`; execute them locally and report results in your PR notes.
+
+## Documentation & Communication
+- Use British English spelling in documentation, UI copy, and inline comments. Editors that honour `.editorconfig` will pick up the `spelling_language = en-GB` hint, and you can extend local spell-checkers with `en-GB` dictionaries when drafting content.
+- Update README sections or files in `docs/` when behaviour or workflows change. Architectural adjustments belong in `docs/architecture/`,
+process updates in `docs/processes/`, and contributor workflows in `docs/development/`.
+- Dashboard-facing changes should also refresh any generated artefacts or usage docs referenced from `.build/visualizations/README.md`.
+- PR summaries must include:
+  1. User- or developer-facing impacts in bullet form.
+  2. A test checklist with the exact commands run and their outcomes.
+- Review `docs/PR_BEST_PRACTICES.md` before opening a pull request to ensure your communication style matches the project norm.
+
+Thanks for contributing, and enjoy exploring the data!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,9 @@ We follow a GitFlow branching strategy:
 - Write docstrings for all functions and classes
 - Code passes mypy static type checking (when configured)
 
+### Documentation Style
+- Write copy and comments in British English (e.g., “favour”, “optimise”). Configure your editor to use an `en-GB` dictionary—our `.editorconfig` file exposes `spelling_language = en-GB` for tools that support it.
+
 ### Type Hints
 All functions should include type annotations for parameters and return values:
 

--- a/scripts/core/data_loader.py
+++ b/scripts/core/data_loader.py
@@ -3,8 +3,7 @@ DataLoader class for reading and managing destination dashboard data.
 
 This module provides a unified interface for loading data from the new CSV structure
 which separates destinations, cost of living, flight prices, and weather data into
-dedicated files with proper no        if forecast_only:
-            df = df[df['forecast_flag']]alization and time-series support.
+dedicated files with proper normalization and time-series support.
 """
 
 import pandas as pd

--- a/scripts/core/data_loader.py
+++ b/scripts/core/data_loader.py
@@ -74,8 +74,10 @@ class DataLoader:
             if normalized == "FALSE":
                 return False
 
-        return False
+        if isinstance(value, (int, float)):
+            return bool(value)
 
+        return False
     def load_destinations(self, reload: bool = False) -> pd.DataFrame:
         """
         Load destination master data.

--- a/scripts/core/data_loader.py
+++ b/scripts/core/data_loader.py
@@ -60,7 +60,23 @@ class DataLoader:
 
     @staticmethod
     def _normalize_forecast_flag(value: Union[str, bool, float, int, None]) -> bool:
-        """Convert various truthy/falsey representations to a boolean."""
+        """
+        Convert various representations to a boolean value.
+
+        Accepted representations:
+            - Boolean values: returned as-is.
+            - Strings: "true"/"false" (case-insensitive, leading/trailing whitespace ignored).
+                - "true" => True
+                - "false" => False
+            - NaN (float('nan'), pd.NA, None): returns False.
+            - All other values (including numerics like 1/0): returns False.
+
+        Args:
+            value (str, bool, float, int, None): Input value to normalize.
+
+        Returns:
+            bool: Normalized boolean value.
+        """
         if isinstance(value, bool):
             return value
 

--- a/scripts/core/data_loader.py
+++ b/scripts/core/data_loader.py
@@ -59,6 +59,24 @@ class DataLoader:
         self.flights_df: Optional[pd.DataFrame] = None
         self.weather_df: Optional[pd.DataFrame] = None
 
+    @staticmethod
+    def _normalize_forecast_flag(value: Union[str, bool, float, int, None]) -> bool:
+        """Convert various truthy/falsey representations to a boolean."""
+        if isinstance(value, bool):
+            return value
+
+        if pd.isna(value):
+            return False
+
+        if isinstance(value, str):
+            normalized = value.strip().upper()
+            if normalized == "TRUE":
+                return True
+            if normalized == "FALSE":
+                return False
+
+        return False
+
     def load_destinations(self, reload: bool = False) -> pd.DataFrame:
         """
         Load destination master data.
@@ -260,9 +278,10 @@ class DataLoader:
                 "destination_id"
             ].astype(int)
 
-            # Parse boolean
-            self.weather_df["forecast_flag"] = self.weather_df["forecast_flag"].astype(
-                bool
+        # Normalize forecast flag values to booleans
+        if "forecast_flag" in self.weather_df.columns:
+            self.weather_df["forecast_flag"] = self.weather_df["forecast_flag"].apply(
+                self._normalize_forecast_flag
             )
 
         df = self.weather_df.copy()

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -239,9 +239,7 @@ class TestDataLoader:
             {
                 "weather_id": [1, 2, 3],
                 "destination_id": [1, 1, 1],
-                "date": pd.to_datetime(
-                    ["2025-10-05", "2025-10-06", "2025-10-07"]
-                ),
+                "date": pd.to_datetime(["2025-10-05", "2025-10-06", "2025-10-07"]),
                 "temp_high_c": [26, 27, 25],
                 "temp_low_c": [18, 19, 17],
                 "temp_avg_c": [22, 23, 21],

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -235,9 +235,34 @@ class TestDataLoader:
 
     def test_load_weather_filter_forecast_only(self, loader):
         """Test filtering weather for forecasts only."""
+        weather_data = pd.DataFrame(
+            {
+                "weather_id": [1, 2, 3],
+                "destination_id": [1, 1, 1],
+                "date": pd.to_datetime(
+                    ["2025-10-05", "2025-10-06", "2025-10-07"]
+                ),
+                "temp_high_c": [26, 27, 25],
+                "temp_low_c": [18, 19, 17],
+                "temp_avg_c": [22, 23, 21],
+                "rainfall_mm": [0, 0, 1],
+                "humidity_percent": [65, 60, 70],
+                "sunshine_hours": [9.5, 10.2, 8.5],
+                "wind_speed_kmh": [12, 10, 15],
+                "conditions": ["Sunny", "Clear", "Partly Cloudy"],
+                "uv_index": [7, 7, 6],
+                "forecast_flag": ["TRUE", "FALSE", True],
+                "data_source": ["demo1", "demo1", "demo1"],
+            }
+        )
+
+        # Inject custom weather data with mixed forecast flag representations
+        loader.weather_df = weather_data
+
         df = loader.load_weather(forecast_only=True)
 
-        assert not df.empty
+        assert len(df) == 2  # Only rows marked as forecast should remain
+        assert df["forecast_flag"].dtype == bool
         assert df["forecast_flag"].all()
 
     def test_load_weather_filter_data_source(self, loader):


### PR DESCRIPTION
## Summary
- add a normalization helper so weather forecast flags consistently map to booleans
- ensure mixed forecast flag inputs are filtered correctly when requesting forecasts only

## Testing
- PYTHONPATH=. pytest tests/test_data_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68e52a0b0fb48332bc0c9c519d8099f8