### PR TITLE
Handle empty cost comparison dashboard inputs

### DIFF
--- a/scripts/visualizations/cost_comparison.py
+++ b/scripts/visualizations/cost_comparison.py
@@ -20,6 +20,7 @@ import logging
 import sys
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 
@@ -308,18 +309,47 @@ def create_cost_dashboard(
     data_date = df["data_date"].iloc[0] if not df.empty else "N/A"
     data_source = df["data_source"].iloc[0] if not df.empty else "N/A"
 
-    # Calculate summary statistics
-    avg_cost = df["monthly_living_cost"].mean()
-    min_cost = df["monthly_living_cost"].min()
-    max_cost = df["monthly_living_cost"].max()
-    min_dest = destinations_df[
-        destinations_df["destination_id"]
-        == df[df["monthly_living_cost"] == min_cost]["destination_id"].iloc[0]
-    ]["name"].iloc[0]
-    max_dest = destinations_df[
-        destinations_df["destination_id"]
-        == df[df["monthly_living_cost"] == max_cost]["destination_id"].iloc[0]
-    ]["name"].iloc[0]
+    # Calculate summary statistics with safety checks for empty/invalid data
+    avg_cost_display = "N/A"
+    min_cost_display = "N/A"
+    max_cost_display = "N/A"
+    range_display = "N/A"
+    min_dest = "N/A"
+    max_dest = "N/A"
+
+    if not df.empty and "monthly_living_cost" in df.columns:
+        numeric_costs = pd.to_numeric(df["monthly_living_cost"], errors="coerce")
+        valid_costs = numeric_costs[np.isfinite(numeric_costs)]
+
+        if not valid_costs.empty:
+            avg_cost_value = float(valid_costs.mean())
+            min_cost_value = float(valid_costs.min())
+            max_cost_value = float(valid_costs.max())
+
+            avg_cost_display = f"£{avg_cost_value:.0f}/mo"
+            min_cost_display = f"£{min_cost_value:.0f}/mo"
+            max_cost_display = f"£{max_cost_value:.0f}/mo"
+            range_display = f"£{(max_cost_value - min_cost_value):.0f}"
+
+            if "destination_id" in df.columns and "destination_id" in destinations_df.columns:
+                min_indices = valid_costs.index[valid_costs == min_cost_value]
+                max_indices = valid_costs.index[valid_costs == max_cost_value]
+
+                if len(min_indices) > 0:
+                    min_dest_id = df.loc[min_indices[0], "destination_id"]
+                    min_dest_match = destinations_df.loc[
+                        destinations_df["destination_id"] == min_dest_id, "name"
+                    ]
+                    if not min_dest_match.empty:
+                        min_dest = str(min_dest_match.iloc[0])
+
+                if len(max_indices) > 0:
+                    max_dest_id = df.loc[max_indices[0], "destination_id"]
+                    max_dest_match = destinations_df.loc[
+                        destinations_df["destination_id"] == max_dest_id, "name"
+                    ]
+                    if not max_dest_match.empty:
+                        max_dest = str(max_dest_match.iloc[0])
 
     # Create all charts
     total_chart = create_total_cost_chart(df, destinations_df)
@@ -434,19 +464,19 @@ def create_cost_dashboard(
         <div class="stats">
             <div class="stat-card">
                 <div class="stat-label">Average Cost</div>
-                <div class="stat-value">£{avg_cost:.0f}/mo</div>
+                <div class="stat-value">{avg_cost_display}</div>
             </div>
             <div class="stat-card">
                 <div class="stat-label">Most Affordable</div>
-                <div class="stat-value">{min_dest}<br><span style="font-size: 18px;">£{min_cost:.0f}/mo</span></div>
+                <div class="stat-value">{min_dest}<br><span style="font-size: 18px;">{min_cost_display}</span></div>
             </div>
             <div class="stat-card">
                 <div class="stat-label">Most Expensive</div>
-                <div class="stat-value">{max_dest}<br><span style="font-size: 18px;">£{max_cost:.0f}/mo</span></div>
+                <div class="stat-value">{max_dest}<br><span style="font-size: 18px;">{max_cost_display}</span></div>
             </div>
             <div class="stat-card">
                 <div class="stat-label">Cost Range</div>
-                <div class="stat-value">£{max_cost - min_cost:.0f}</div>
+                <div class="stat-value">{range_display}</div>
             </div>
         </div>
 

--- a/tests/test_cost_comparison.py
+++ b/tests/test_cost_comparison.py
@@ -7,6 +7,7 @@ import pytest
 
 from scripts.visualizations.cost_comparison import (
     create_category_comparison_chart,
+    create_cost_dashboard,
     create_cost_breakdown_chart,
     create_cost_distribution_chart,
     create_total_cost_chart,
@@ -282,3 +283,36 @@ class TestCostComparisonIntegration:
         assert "Most Affordable" in content
         assert "Most Expensive" in content
         assert "Cost Range" in content
+
+    def test_create_cost_dashboard_handles_empty_dataframe(
+        self, tmp_path, sample_destinations_df
+    ):
+        """Test that dashboard generation handles empty cost data gracefully."""
+
+        empty_df = pd.DataFrame(
+            {
+                "destination_id": pd.Series(dtype="int64"),
+                "data_date": pd.Series(dtype="datetime64[ns]"),
+                "data_source": pd.Series(dtype="object"),
+                "currency": pd.Series(dtype="object"),
+                "monthly_living_cost": pd.Series(dtype="float64"),
+                "rent_1br_center": pd.Series(dtype="float64"),
+                "rent_1br_outside": pd.Series(dtype="float64"),
+                "monthly_food": pd.Series(dtype="float64"),
+                "monthly_transport": pd.Series(dtype="float64"),
+                "utilities": pd.Series(dtype="float64"),
+                "internet": pd.Series(dtype="float64"),
+                "meal_inexpensive": pd.Series(dtype="float64"),
+                "meal_mid_range": pd.Series(dtype="float64"),
+                "beer_domestic": pd.Series(dtype="float64"),
+                "weed_cost_per_gram": pd.Series(dtype="float64"),
+            }
+        )
+
+        output_path = tmp_path / "cost_comparison_empty.html"
+
+        create_cost_dashboard(output_path, empty_df, sample_destinations_df)
+
+        assert output_path.exists()
+        content = output_path.read_text()
+        assert "N/A" in content


### PR DESCRIPTION
## Summary
- add defensive checks for the cost comparison dashboard summary statistics when data is missing
- show fallback labels for summary metric cards so empty datasets render safely
- add a regression test that exercises `create_cost_dashboard` with an empty DataFrame

## Testing
- PYTHONPATH=. pytest tests/test_cost_comparison.py


------
https://chatgpt.com/codex/tasks/task_e_68e52d670a4c8332be2b13d30ba9f9ee