### PR TITLE
Add sunshine helpers and flight link styling

### DIFF
--- a/docs/project/beer_in_the_sun.md
+++ b/docs/project/beer_in_the_sun.md
@@ -1,0 +1,55 @@
+# Beer in the sun
+
+"Beer in the sun" is a lightweight concept for identifying spots that receive
+direct sunshine—perfect for picking a sunny bench, beer garden table, or picnic
+patch. The approach models how nearby buildings or trees cast shadows so that
+we can answer the simple question: *is this spot in sunshine right now?*
+
+## Problem statement
+
+- Users want to know whether a given outdoor spot is currently sunlit.
+- Buildings, walls, signage, and foliage all cast shadows that move throughout
+  the day.
+- A practical solution should work with limited inputs: the Sun's azimuth and
+  altitude plus rough obstacle outlines.
+
+## Modelling approach
+
+1. **Sun position** — Represent the Sun at a moment in time as azimuth and
+   altitude angles.
+2. **Obstacles** — Describe obstructions by the azimuth span they occupy around
+   the observer and the elevation angle they block above the horizon.
+3. **Visibility check** — If the Sun sits within an obstacle's azimuth span *and*
+   below its elevation angle, the spot is shaded; otherwise it is in sunshine.
+
+This simplified geometry is fast to compute and works well with coarse obstacle
+data (e.g., a skyline scan from a phone compass). It can be extended later with
+polygons, time-dependent structures, or light-diffusion models.
+
+## Implementation snippet
+
+The module `scripts/core/sunlight.py` contains reusable helpers:
+
+```python
+from scripts.core.sunlight import Obstacle, SunPosition, is_in_sunshine
+
+# Define a nearby office block that covers 150°–210° azimuth up to 20° elevation
+office_block = Obstacle(azimuth_start=150, azimuth_end=210, elevation=20)
+
+# Example Sun position at 14:30 (azimuth and altitude in degrees)
+sun_now = SunPosition(azimuth=185, altitude=35)
+
+if is_in_sunshine(sun_now, obstacles=[office_block], altitude_threshold=1.0):
+    print("This bench is in sunshine.")
+else:
+    print("It is currently shaded.")
+```
+
+## Next steps
+
+- Collect azimuth/elevation scans for common beer garden layouts to seed
+  obstacle libraries.
+- Integrate a solar position library (e.g., `astral`) to generate accurate
+  `SunPosition` values by location and time.
+- Pair with forecast data to surface "sunny hour" recommendations for each
+  venue.

--- a/scripts/core/sunlight.py
+++ b/scripts/core/sunlight.py
@@ -1,0 +1,147 @@
+"""Sunlight visibility utilities for the "Beer in the sun" use case.
+
+The helpers in this module provide a simple way to express whether a point is
+in direct sunshine while accounting for surrounding obstructions such as
+buildings, trees, or temporary structures. The geometry is intentionally
+minimal: obstacles are modelled by the azimuth range they occupy around the
+observer and the elevation angle they block above the horizon. If the Sun is
+within the blocked azimuth range *and* below the obstacle's elevation angle,
+the location is considered shaded; otherwise it is in sunshine.
+"""
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+def _normalise_azimuth(angle: float) -> float:
+    """Normalise an azimuth angle to the range [0, 360).
+
+    Args:
+        angle: Raw azimuth angle in degrees. Positive and negative values are
+            accepted.
+
+    Returns:
+        The input angle mapped onto the interval [0, 360).
+    """
+
+    return angle % 360
+
+
+def _azimuth_in_range(angle: float, start: float, end: float) -> bool:
+    """Check whether an angle lies within an azimuth span, handling wrap-around.
+
+    The function works even when the azimuth window crosses north (e.g., a
+    building running from 350° to 15°).
+
+    Args:
+        angle: Azimuth of interest in degrees.
+        start: Start of the azimuth window in degrees.
+        end: End of the azimuth window in degrees.
+
+    Returns:
+        True if the angle falls inside the azimuth range; otherwise False.
+    """
+
+    normalised_angle = _normalise_azimuth(angle)
+    normalised_start = _normalise_azimuth(start)
+    normalised_end = _normalise_azimuth(end)
+
+    if normalised_start <= normalised_end:
+        return normalised_start <= normalised_angle <= normalised_end
+
+    # Range crosses north; treat it as two joined intervals.
+    return normalised_angle >= normalised_start or normalised_angle <= normalised_end
+
+
+@dataclass(frozen=True)
+class SunPosition:
+    """Represents the Sun's apparent position for a given moment in time."""
+
+    azimuth: float
+    altitude: float
+
+    def is_above_horizon(self, threshold: float = 0.0) -> bool:
+        """Return True when the Sun is above the specified altitude threshold."""
+
+        return self.altitude > threshold
+
+
+@dataclass(frozen=True)
+class Obstacle:
+    """A static obstruction described by its azimuth span and elevation angle."""
+
+    azimuth_start: float
+    azimuth_end: float
+    elevation: float
+    name: str = "obstacle"
+
+    def blocks(self, sun_position: SunPosition) -> bool:
+        """Determine whether this obstacle blocks direct sunshine.
+
+        An obstacle blocks sunshine when the Sun is within its azimuth span and
+        sits below the obstacle's elevation angle.
+        """
+
+        if sun_position.altitude > self.elevation:
+            return False
+
+        return _azimuth_in_range(
+            sun_position.azimuth, self.azimuth_start, self.azimuth_end
+        )
+
+
+def is_in_sunshine(
+    sun_position: SunPosition,
+    obstacles: Iterable[Obstacle] | None = None,
+    altitude_threshold: float = 0.0,
+) -> bool:
+    """Return True when the spot has direct sunshine.
+
+    Args:
+        sun_position: The Sun's azimuth and altitude at the observation point.
+        obstacles: Any surrounding obstacles that may block the Sun.
+        altitude_threshold: Minimum altitude (in degrees) that counts as
+            sunshine. This helps ignore twilight conditions where shadows are
+            effectively infinite.
+    """
+
+    if not sun_position.is_above_horizon(altitude_threshold):
+        return False
+
+    blocking_obstacles: List[Obstacle] = list(obstacles or [])
+
+    return not any(obstacle.blocks(sun_position) for obstacle in blocking_obstacles)
+
+
+def sunshine_ratio(
+    sun_positions: Iterable[SunPosition],
+    obstacles: Iterable[Obstacle] | None = None,
+    altitude_threshold: float = 0.0,
+) -> float:
+    """Calculate the fraction of supplied moments that are in sunshine.
+
+    Args:
+        sun_positions: Sequence of Sun positions (for example, at five-minute
+            intervals across an afternoon).
+        obstacles: Surrounding obstacles to test against.
+        altitude_threshold: Minimum altitude (in degrees) that counts as
+            sunshine.
+
+    Returns:
+        A value between 0 and 1 indicating the proportion of moments that have
+        sunshine.
+    """
+
+    sun_positions_list = list(sun_positions)
+    if not sun_positions_list:
+        return 0.0
+
+    sunlit_count = sum(
+        1
+        for position in sun_positions_list
+        if is_in_sunshine(
+            position, obstacles=obstacles, altitude_threshold=altitude_threshold
+        )
+    )
+
+    return sunlit_count / len(sun_positions_list)

--- a/scripts/visualizations/tabular_dashboard.py
+++ b/scripts/visualizations/tabular_dashboard.py
@@ -183,6 +183,14 @@ def create_tabular_dashboard(
         .cost {{
             background-color: #fff9e6;
         }}
+        .flight-price a {{
+            color: #1a5276;
+            text-decoration: none;
+            font-weight: 600;
+        }}
+        .flight-price a:hover {{
+            text-decoration: underline;
+        }}
         /* Flight price gradient: cheap (green) to expensive (red) */
         .flight-cheap {{
             background-color: #c8e6c9;
@@ -430,9 +438,14 @@ def create_tabular_dashboard(
 
     # Flight Prices Section
     if not flights_df.empty and "departure_date" in flights_df.columns:
-        html += """                <!-- Flight Prices Section -->
+        origin_label_map = {"EXT": "EXETER", "BRS": "BRISTOL"}
+        section_origin = origin_label_map.get(
+            origin_airport.upper(), origin_airport.upper()
+        )
+
+        html += f"""                <!-- Flight Prices Section -->
                 <tr>
-                    <td class="section-header" colspan="999">FLIGHTS (£)</td>
+                    <td class="section-header" colspan="999">FLIGHTS FROM {section_origin} (£)</td>
                 </tr>
 """
         # Exeter flights
@@ -476,7 +489,7 @@ def create_tabular_dashboard(
                     price_class = "flight-very-expensive"
 
                 html += (
-                    f'                    <td class="{price_class}">'
+                    f'                    <td class="{price_class} flight-price">'
                     f'<a href="{flight_url}" target="_blank" '
                     f'title="Search flights on Skyscanner">£{min_price:.0f}</a></td>\n'
                 )
@@ -525,7 +538,7 @@ def create_tabular_dashboard(
                     price_class = "flight-very-expensive"
 
                 html += (
-                    f'                    <td class="{price_class}">'
+                    f'                    <td class="{price_class} flight-price">'
                     f'<a href="{flight_url}" target="_blank" '
                     f'title="Search flights on Skyscanner">£{min_price:.0f}</a></td>\n'
                 )

--- a/tests/test_sunlight.py
+++ b/tests/test_sunlight.py
@@ -1,0 +1,52 @@
+"""Unit tests for the sunlight visibility helpers."""
+
+from scripts.core.sunlight import (
+    Obstacle,
+    SunPosition,
+    _azimuth_in_range,
+    is_in_sunshine,
+    sunshine_ratio,
+)
+
+
+def test_azimuth_range_wraps_north():
+    """Ranges that cross north should still match values on either side."""
+
+    assert _azimuth_in_range(355, 350, 10)
+    assert _azimuth_in_range(5, 350, 10)
+    assert not _azimuth_in_range(45, 350, 10)
+
+
+def test_obstacle_blocks_low_sun():
+    """Buildings with sufficient elevation should block low-altitude sun."""
+
+    sun = SunPosition(azimuth=180, altitude=12)
+    building = Obstacle(azimuth_start=150, azimuth_end=210, elevation=20, name="office")
+
+    assert not is_in_sunshine(sun, obstacles=[building])
+
+
+def test_sunshine_when_above_obstacle():
+    """A taller Sun altitude than the obstacle height should not be blocked."""
+
+    sun = SunPosition(azimuth=185, altitude=35)
+    building = Obstacle(azimuth_start=150, azimuth_end=210, elevation=20, name="office")
+
+    assert is_in_sunshine(sun, obstacles=[building])
+
+
+def test_sunshine_ratio_counts_multiple_positions():
+    """The sunshine ratio should reflect the share of unblocked moments."""
+
+    building = Obstacle(azimuth_start=260, azimuth_end=310, elevation=25, name="tower")
+    sun_positions = [
+        SunPosition(azimuth=270, altitude=15),  # blocked by tower
+        SunPosition(azimuth=240, altitude=15),  # clear
+        SunPosition(azimuth=90, altitude=5),  # clear
+        SunPosition(azimuth=300, altitude=30),  # above tower
+    ]
+
+    assert (
+        sunshine_ratio(sun_positions, obstacles=[building], altitude_threshold=1.0)
+        == 0.75
+    )


### PR DESCRIPTION
## Summary
- add sunlight visibility helpers for the "Beer in the sun" concept plus accompanying documentation
- style tabular dashboard flight links and include origin context in the flights section header
- cover sunshine logic with new unit tests

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f85e13a3883329479d086a8eadedf)